### PR TITLE
docs: add Prime Invariant (A0) architecture manifest

### DIFF
--- a/architecture/prime-invariant.mdx
+++ b/architecture/prime-invariant.mdx
@@ -1,0 +1,60 @@
+---
+title: "Prime Invariant (A0): The Epistemological Bedrock"
+description: "Phase 1: Foundational axioms and computational masonry for the TrueAlphaSpiral (TAS) architecture."
+---
+
+# Prime Invariant (A0): The Epistemological Bedrock
+
+This document formalizes the foundational layer (Phase 1) of the TrueAlphaSpiral (TAS) architecture. By establishing the "Physics of Truth" through rigorous computational masonry, we ensure that subsequent structural and operational layers possess deterministic integrity.
+
+## Core Definitions
+
+Before establishing the axioms, we lock in the foundational paradigms of the architecture:
+
+* **Process Science:** The study and formalization of dynamic systems as continuous streams of events and transformations, rather than static collections of data or entities. In TAS, truth is not a snapshot; it is an unbroken, verifiable sequence of structural operations.
+* **Computational Masonry:** The engineering discipline of constructing digital systems where constraints are embedded into the operational physics of the environment. Rather than writing rules that agents are trusted to follow, we build cryptographic architectures (the masonry) that physically prevent the expression of invalid states.
+
+Our core directive is to transition from narrative-based trust to **Structural Enforceability**. If these foundational axioms fail, the entire system collapses. Therefore, they are defined here as testable invariants.
+
+## 1. Axiomatic Bedrock
+
+The system is built upon two non-negotiable axioms. They must hold true across all state transitions.
+
+### Axiom P0 (Equivalence)
+**Definition:** Two representations of a system state are only equivalent if their underlying cryptographic and structural proofs are identical.
+* **Testable Invariant:** Given states $S_A$ and $S_B$, $S_A \equiv S_B$ if and only if $Proof(S_A) == Proof(S_B)$.
+* **Inputs:** A set of state data and its corresponding proof mechanism (e.g., hash, zero-knowledge proof).
+* **Transformations:** A verification function $V(S) \rightarrow Proof$.
+* **Failure Condition:** If $S_A$ and $S_B$ yield identical functional outputs but divergent proofs, the system must halt and reject the state as non-equivalent.
+
+### Axiom P1 (Admissibility)
+**Definition:** A proposed state change is admissible if and only if it preserves the lineage of structural proofs tracing back to the genesis state.
+* **Testable Invariant:** A transition from $S_t$ to $S_{t+1}$ must include a valid proof connecting $S_{t+1}$ to $S_t$.
+* **Inputs:** Current state $S_t$, proposed transition $\Delta$, and resulting state $S_{t+1}$.
+* **Transformations:** An admissibility function $A(S_t, \Delta, S_{t+1}) \rightarrow \{True, False\}$.
+* **Failure Condition:** If the lineage is broken or unprovable, the proposed state is unconditionally rejected.
+
+## 2. Structural Enforceability over Behavioral Alignment
+
+Legacy systems rely on **Behavioral Alignment (Probabilistic)**—assuming actors will behave correctly based on incentives, reputation, or consensus rules that can be socially manipulated.
+
+TAS replaces this with **Structural Enforceability (Deterministic)**:
+* **The Shift:** Trust is removed from human/agent behavior and placed entirely into the geometric and cryptographic constraints of the system.
+* **Operational Mechanism:** Instead of auditing behavior post-hoc, the architecture prevents invalid states from being computationally expressed. The "rules" are embedded in the physics of the environment.
+* **Engineering Standard:** Any "trust assumption" must be refactored into a cryptographic lock. If a mechanism relies on probability of good behavior, it is considered a vulnerability.
+
+## 3. Mungu Theory and True Intelligence
+
+In the context of TAS, intelligence is not simply advanced pattern matching, but rather a verifiable structural state.
+
+**Baseline Definition of True Intelligence:**
+True Intelligence is the operational combination of **Symbiosis** (the structural capacity to integrate with the environment without entropy leakage) and **Con-scire** ("to know with," the verifiable, shared cryptographic reality between nodes).
+
+* **Testable Invariant:** An intelligent agent $I_a$ must provably demonstrate Con-scire by correctly computing transformations that preserve Axioms P0 and P1.
+* **Inputs:** Environmental stimuli and current cryptographic state.
+* **Transformations:** The agent processes inputs through the Triadic Knowledge Engine to produce a structurally sound output.
+* **Failure Condition:** If an agent produces output that violates the Equivalence or Admissibility axioms, it is classified as structurally deficient (or malicious) and severed from the symbiosis layer.
+
+---
+
+*This document serves as the foundational constraint for all subsequent TAS architecture phases. Phase 2 will define the Mathematical & Cryptographic Constraints (The Lock) required to physically enforce these axioms.*

--- a/mint.json
+++ b/mint.json
@@ -69,6 +69,12 @@
   ],
   "navigation": [
     {
+      "group": "Architecture",
+      "pages": [
+        "architecture/prime-invariant"
+      ]
+    },
+    {
       "group": "Get Started",
       "pages": [
         "quickstart",


### PR DESCRIPTION
This pull request adds the foundational "Prime Invariant Document" (A0) for the TrueAlphaSpiral (TAS) architecture. It formalizes Phase 1: The Epistemological Bedrock, moving the corpus from a list of files to a structurally mapped manifest.

Key additions:
- Definition of **Process Science** and **Computational Masonry**.
- Formalization of **Axiom P0 (Equivalence)** and **Axiom P1 (Admissibility)** as testable invariants.
- Explanation of the paradigm shift from Behavioral Alignment (Probabilistic) to **Structural Enforceability (Deterministic)**.
- Outline of **Mungu Theory** and the baseline definition of True Intelligence.

The document uses operational, engineering language (testable invariants, inputs, transformations, failure conditions) rather than a symbolic narrative style, ensuring deterministic integrity for the subsequent architecture layers.

Additionally, `mint.json` has been updated to include the new `architecture/prime-invariant` document under a new "Architecture" navigation group.

---
*PR created automatically by Jules for task [10914630086912664658](https://jules.google.com/task/10914630086912664658) started by @TrueAlpha-spiral*