### PR TITLE
🔒 [security fix] Remove hardcoded webhook secret from documentation

### DIFF
--- a/account-management/webhooks.mdx
+++ b/account-management/webhooks.mdx
@@ -48,7 +48,7 @@ Our webhook partner Svix offers a set of useful libraries that make verifying we
 ```typescript
 import { Webhook } from "svix";
 
-const secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
+const secret = process.env.WEBHOOK_SECRET;
 
 // These were all sent from the server
 const headers = {
@@ -60,7 +60,7 @@ const payload = '{"test": 2432232314}';
 
 const wh = new Webhook(secret);
 // Throws on error, returns the verified content on success
-const payload = wh.verify(payload, headers);
+const verifiedPayload = wh.verify(payload, headers);
 ```
 
 For more instructions and examples of how to verify signatures, check out their [webhook verification documentation](https://docs.svix.com/receiving/verifying-payloads/how).


### PR DESCRIPTION
🎯 **What:** Fixed a hardcoded webhook secret in `account-management/webhooks.mdx` and a duplicate variable declaration in the same code snippet.
⚠️ **Risk:** Hardcoding secrets in documentation can lead to accidental exposure of sensitive credentials if users copy-paste the example without modification. It also sets a poor security example. The duplicate `const` declaration would cause a `SyntaxError` at runtime.
🛡️ **Solution:** Replaced the hardcoded string with `process.env.WEBHOOK_SECRET` and renamed the second `payload` declaration to `verifiedPayload`. Verified the fix with a standalone Node.js test script.

---
*PR created automatically by Jules for task [12986744249311486660](https://jules.google.com/task/12986744249311486660) started by @TrueAlpha-spiral*