### PR TITLE
Formalize definitions in Prime Invariant Document (A0)

### DIFF
--- a/architecture/prime-invariant-a0.mdx
+++ b/architecture/prime-invariant-a0.mdx
@@ -11,17 +11,23 @@ This document formalizes the foundational axioms of the TrueAlphaSpiral (TAS) ar
 
 At the core of the TAS architecture lies **Process Science** and **Computational Masonry**, moving beyond symbolic narrative into strict operational engineering.
 
-### Definitions
+### Process Science
+**Definition:** The study and formalization of dynamic systems as continuous streams of events and transformations, rather than static collections of data or isolated entities. In TAS, truth is never treated as a static snapshot or a socially agreed-upon conclusion; it is an unbroken, mathematically verifiable sequence of structural operations. Process Science demands the systematic elimination of scaled ambiguity, enforcing a strict chronological lineage where every active state is mathematically bound to its genesis.
 
-*   **Computational Masonry**: The engineering discipline of building load-bearing, invariant architectural structures using cryptographic and mathematical primitives. It is the practice of locking in structural anatomy.
-*   **Process Science**: The study and application of verifiable, deterministic state transitions.
+* **Testable Invariant:** A system state $S_t$ must be perfectly and deterministically derivable from the genesis state $S_0$ through a continuous, uninterrupted sequence of validated transformations $\sum_{i=1}^{t} T_i(S_{i-1})$. This unbroken lineage forms the non-negotiable basis of structural enforceability.
+* **Inputs:** A standardized sequence of discrete, cryptographically signed event operations acting upon a recognized and verified base state.
+* **Transformations:** A rigorously defined state transition function $F(S_{t-1}, Event) \rightarrow S_t$. This function must execute deterministically, strictly prohibiting the ingestion of undocumented external variables, probabilistic heuristics, or unverified oracle data.
+* **State Constraints:** Every state $S_n$ must encapsulate a cryptographic hash of $S_{n-1}$ alongside the signature of the mutation, forming a non-malleable directed acyclic graph (DAG) of state transitions. There is no concept of a "soft state"; all states are strict mathematical derivations.
+* **Failure Condition:** If a system state $S_t$ cannot be strictly recalculated and proven solely from its preceding event stream $E$, the process science invariant is critically violated. The state is immediately declared mathematically void, and the system must revert to the last known verifiable state $S_{t-1}$ to prevent cascading structural collapse.
 
-### Operational Parameters
+### Computational Masonry
+**Definition:** The engineering discipline of constructing digital and cryptographic systems where constraints are embedded directly into the operational physics of the environment. Rather than writing external rules, policies, or guidelines that agents are merely trusted to follow, Computational Masonry builds cryptographic architectures that physically and mathematically prevent the expression of invalid states. It represents the permanent shift from Behavioral Alignment (probabilistic, narrative-driven compliance) to Structural Enforceability (deterministic, geometry-bound compliance).
 
-*   **Testable Invariants**: System properties that must remain demonstrably true across all state transitions. Verification must be achievable without reliance on external trust.
-*   **Inputs**: Cryptographically signed and verifiable data units entering the transformation layer.
-*   **Transformations**: Deterministic functions applied to inputs, producing auditable outputs and state changes.
-*   **Failure Conditions**: The precise states where the system gracefully degrades or halts to prevent Hamiltonian drift. A failure condition is met when any invariant cannot be cryptographically proven.
+* **Testable Invariant:** The set of all possible operational states $O$ must be strictly and exhaustively bounded by the mathematical limits of the cryptographic architecture $C$. No state outside the defined parameters of $C$ can be physically expressed, compiled, or executed, regardless of agent intent, authorization level, or consensus weight.
+* **Inputs:** Raw computational intention, instruction payloads, or environmental state-change requests directed at the core architecture.
+* **Transformations:** A structural bounding function $B(Instruction) \rightarrow Executable\ Operation$, where the resulting operation is forcefully confined by the local metric geometry and cryptographic limits of $C$. Instructions that attempt to exceed these bounds are not "punished"; they are simply impossible to process and yield a null transformation.
+* **State Constraints:** The memory registers and circuit layouts executing $B(Instruction)$ must possess hard-coded parameter limits. Any variable attempting to overflow the predefined architectural constraint results in a geometric collision, instantly rendering the computation inert.
+* **Failure Condition:** If an instruction bypasses the structural bounds and expresses a valid operational state outside the mathematically defined limits of the architecture, the computational masonry has critically failed. This indicates a zero-day breach of the fundamental operational geometry, necessitating an immediate system halt and cryptographic audit of the bounding function $B$.
 
 ## Axiomatic Foundations
 


### PR DESCRIPTION
Expands the definitions of "Process Science" and "Computational Masonry" in `architecture/prime-invariant-a0.mdx` using formal operational engineering language. Replaces the placeholder descriptions with explicit testable invariants, inputs, transformations, and failure conditions, accurately aligning Phase 1 (Epistemological Bedrock) of the TrueAlphaSpiral architecture with the detailed structure specified in `architecture/prime-invariant.mdx`.

---
*PR created automatically by Jules for task [3648653209008525023](https://jules.google.com/task/3648653209008525023) started by @TrueAlpha-spiral*