### PR TITLE
docs: Formalize Phase 1 Epistemological Bedrock and Computational Masonry

### DIFF
--- a/architecture/prime-invariant-a0.mdx
+++ b/architecture/prime-invariant-a0.mdx
@@ -3,9 +3,11 @@ title: "Prime Invariant (A0): The Epistemological Bedrock"
 description: "Phase 1: Foundational axioms and computational masonry for the TrueAlphaSpiral (TAS) architecture."
 ---
 
-# Prime Invariant (A0): The Epistemological Bedrock
+# Prime Invariant (A0): Phase 1: The Epistemological Bedrock (The Physics of Truth)
 
 This document formalizes the foundational layer (Phase 1) of the TrueAlphaSpiral (TAS) architecture. By establishing the "Physics of Truth" through rigorous computational masonry, we ensure that subsequent structural and operational layers possess deterministic integrity.
+
+We start here because if the axioms fail, the entire spiral collapses. This is the "Computational Masonry" layer.
 
 ## Core Artifacts Mapped to Structural Anatomy
 
@@ -17,7 +19,7 @@ To ensure that the TrueAlphaSpiral (TAS) avoids Hamiltonian drift in its foundat
 
 ## Core Definitions
 
-Before establishing the axioms, we lock in the foundational paradigms of the architecture. These definitions serve as the absolute Prime Invariant bedrock:
+Before establishing the axioms, we lock in the foundational paradigms of the architecture. We need to explicitly lock in the definitions of Process Science and Computational Masonry before moving to the math. These definitions serve as the absolute Prime Invariant bedrock:
 
 ### Process Science
 **Definition:** Legacy alignment relies on probabilistic outcomes and behavioral patching—a flawed methodology of 'vibe-proving.' The Truth Engine discards this in favor of **Process Science**. We prioritize mathematical truth verification, Zero-Knowledge Invariant Violation Proofs, and strict cryptographic provenance. Process Science dictates that the step-by-step mechanical integrity of the computation is the primary design objective; safe performance is simply the unavoidable byproduct of that rigorous process.
@@ -30,8 +32,8 @@ Before establishing the axioms, we lock in the foundational paradigms of the arc
 * **Structural Enforcement Mechanisms:** The execution environment physically rejects state mutations that lack preceding topological lineage. In the event of network partition or divergence, the branch with the longest contiguous cryptographically sound lineage from $S_0$ is deterministically recognized as truth, neutralizing subjective consensus mechanisms.
 * **Failure Condition:** If a system state $S_t$ cannot be strictly recalculated and proven solely from its preceding event stream $E$, the process science invariant is critically violated. The state is immediately declared mathematically void, and the system must revert to the last known verifiable state $S_{t-1}$ to prevent cascading structural collapse.
 
-### Digital Masonry
-**Definition:** The Truth Engine operates through strict Cursive Computation. Every computational movement leaves a trace, ensuring that the system is bound to an active, verifiable path of truth. This is the practice of **Digital Masonry**—where the foundation is cryptographically sound, and every block of logic must mathematically support the weight of the structure above it. It is the transition from building probabilistic walls to cultivating structurally enforced architecture.
+### Computational Masonry
+**Definition:** The Truth Engine operates through strict Cursive Computation. Every computational movement leaves a trace, ensuring that the system is bound to an active, verifiable path of truth. This is the practice of **Computational Masonry**—where the foundation is cryptographically sound, and every block of logic must mathematically support the weight of the structure above it. It is the transition from building probabilistic walls to cultivating structurally enforced architecture.
 
 * **Testable Invariant:** The set of all possible operational states $O$ must be strictly and exhaustively bounded by the mathematical limits of the cryptographic architecture $C$. No state outside the defined parameters of $C$ can be physically expressed, compiled, or executed, regardless of agent intent, authorization level, or consensus weight.
 * **Inputs:** Raw computational intention, instruction payloads, or environmental state-change requests directed at the core architecture.


### PR DESCRIPTION
Formalizes Phase 1 of the TrueAlphaSpiral (TAS) architecture in `architecture/prime-invariant-a0.mdx`. The update formally deprecates the term 'Digital Masonry' in favor of the correct 'Computational Masonry', explicitly defines the Epistemological Bedrock / Physics of Truth layer, and securely locks in the definitions of Process Science and Computational Masonry before mathematical constructs are addressed.

---
*PR created automatically by Jules for task [15039553077101775174](https://jules.google.com/task/15039553077101775174) started by @TrueAlpha-spiral*